### PR TITLE
Add Dockerfile for deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:latest
+
+RUN npm install -g ng-cli \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+      nginx \
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -sf /dev/stdout /var/log/nginx/access.log \
+ && ln -sf /dev/stderr /var/log/nginx/error.log
+
+COPY . /usr/src/app
+
+RUN cd /usr/src/app \
+ && npm install \
+ && npm run-script build \
+ && find /usr/src/app/dist \
+ && rm /var/www/html/index.nginx-debian.html \
+ && cp -r /usr/src/app/dist/* /var/www/html/
+
+EXPOSE 80
+
+ENTRYPOINT []
+CMD ["nginx", "-g", "daemon off;"]
+


### PR DESCRIPTION
Adds a Dockerfile that we can use to deploy the frontend in a static
webhost. The source and biuld tooling are in the contiainer but aren't
used during runtime.