### PR TITLE
Use envsubst to set proper domain for API endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ RUN cd /usr/src/app \
  && find /usr/src/app/dist \
  && rm /var/www/html/index.nginx-debian.html \
  && cp -r /usr/src/app/dist/* /var/www/html/ \
- && cp nginx.conf /etc/nginx/sites-enabled/default
+ && cp nginx.conf /etc/nginx/default.template
 
 EXPOSE 80
 
 ENTRYPOINT []
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/bin/bash", "-c", "envsubst < /etc/nginx/default.template > /etc/nginx/sites-enabled/default && nginx -g 'daemon off;'"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN npm install -g ng-cli \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
       nginx \
+      gettext \
  && rm -rf /var/lib/apt/lists/* \
  && ln -sf /dev/stdout /var/log/nginx/access.log \
  && ln -sf /dev/stderr /var/log/nginx/error.log

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,8 +9,7 @@ server {
 	server_name _;
 
 	location /api {
-    resolver 127.0.0.11 valid=30s;
-		proxy_pass http://api:3000$request_uri;
+		proxy_pass http://${API_HOST}:3000$request_uri;
 	}
 
 	location / {


### PR DESCRIPTION
Since nginx doesn't use /etc/hosts to resolve hostnames, installing DNSmasq is overkill, and nginx can't use environment variables, I propose to make use of envsubst to replace environment variables within the nginx site configuration.