### PR TITLE
Use docker network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN npm install -g ng-cli \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
       nginx \
-      gettext \
  && rm -rf /var/lib/apt/lists/* \
  && ln -sf /dev/stdout /var/log/nginx/access.log \
  && ln -sf /dev/stderr /var/log/nginx/error.log
@@ -17,10 +16,10 @@ RUN cd /usr/src/app \
  && find /usr/src/app/dist \
  && rm /var/www/html/index.nginx-debian.html \
  && cp -r /usr/src/app/dist/* /var/www/html/ \
- && cp nginx.conf /etc/nginx/default.template
+ && cp nginx.conf /etc/nginx/sites-enabled/default
 
 EXPOSE 80
 
 ENTRYPOINT []
-CMD ["/bin/bash", "-c", "envsubst < /etc/nginx/default.template > /etc/nginx/sites-enabled/default && nginx -g 'daemon off;'"]
+CMD ["nginx", "-g", "daemon off;"]
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,8 @@ server {
 	server_name _;
 
 	location /api {
-		proxy_pass https://${API_HOST}$request_uri;
+	  resolver 127.0.0.11;
+		proxy_pass http://api:3000$request_uri;
 	}
 
 	location / {


### PR DESCRIPTION
I've removed the whole environment variable substituion in the nginx config, and instead made it work using docker networks.
In docker-compose v2, we can use 127.0.0.11 as resolver, since that's always added to a network.

To make the new docker-compose.yml work properly, this PR needs to be merged first.