### PR TITLE
Implement speaking URLs for groups

### DIFF
--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -30,7 +30,7 @@
     <div class="col-md-3">
       <h4>Trupp</h4>
       <div *ngFor="let group of groups | groupTypeFilter: 'Trupp' ">
-        <button id="groupButton1" class="btn btn-secondary col-sm-6 groupButton" (click)="selectGroup(group)">
+        <button id="groupButton1" class="btn btn-secondary col-sm-6 groupButton group-name" (click)="selectGroup(group)">
           {{group.name}}
         </button>
       </div>
@@ -38,7 +38,7 @@
     <div class="col-md-3">
       <h4>Meute</h4>
       <div *ngFor="let group of groups | groupTypeFilter: 'Meute' ">
-        <button id="groupButton2" class="btn btn-secondary col-sm-6 groupButton" (click)="selectGroup(group)">
+        <button id="groupButton2" class="btn btn-secondary col-sm-6 groupButton group-name" (click)="selectGroup(group)">
           {{group.name}}
         </button>
       </div>
@@ -46,7 +46,7 @@
     <div class="col-md-3">
       <h4>Equipe</h4>
       <div *ngFor="let group of groups | groupTypeFilter: 'Equipe' ">
-        <button id="groupButton3" class="btn btn-secondary col-sm-6 groupButton" (click)="selectGroup(group)">
+        <button id="groupButton3" class="btn btn-secondary col-sm-6 groupButton group-name" (click)="selectGroup(group)">
             {{group.name}}
         </button>
       </div>
@@ -253,8 +253,8 @@
               <h5 id="date" class="card-text_preview" *ngIf="!tageler.free">{{ tagelerForm.value.date_start | convertToLocalDate }}, {{tagelerForm.value.time_start}} Uhr bis {{tagelerForm.value.date_end | convertToLocalDate }}, {{tagelerForm.value.time_end}} Uhr</h5>
               <h5 id="date_free" class="card-text_preview" *ngIf="tageler.free"> {{ tagelerForm.value.date_start | date: 'fullDate'}}</h5>
               <p id="text" class="card-text_preview" [innerHTML]="tageler.text | sanitizeHtml"></p>
-              <p id="group" class="card-text_preview" *ngIf="!update && group" [innerHTML]="group.toString().split(',').join('<br \>')"></p>
-              <p id="groupUpdate" class="card-text_preview" *ngIf="update" [innerHTML]="tageler.group.toString().split(',').join('<br \>')"></p>
+              <p id="group" class="card-text_preview group-name" *ngIf="!update && group" [innerHTML]="group.toString().split(',').join('<br \>')"></p>
+              <p id="groupUpdate" class="card-text_preview group-name" *ngIf="update" [innerHTML]="tageler.group.toString().split(',').join('<br \>')"></p>
               <p id="bringAlong" class="card-text_preview" *ngIf="!tageler.free">Mitbringen: {{tagelerForm.value.bringAlong}}</p>
               <p id="uniform" class="card-text_preview" *ngIf="!tageler.free">Anziehen: {{tagelerForm.value.uniform}}</p>
             </div>
@@ -343,14 +343,14 @@
             <h5 class="card-title">{{tageler.start | date: 'fullDate'}}</h5>
             <div *ngIf="tageler.group[0]">
               <div *ngIf="tageler.group[0].split(',').length <= 3">
-                <h5 class="card-text">{{tageler.group}}</h5>
+                <h5 class="card-text group-name">{{tageler.group}}</h5>
               </div>
               <div *ngIf="tageler.group[0].split(',').length > 3">
-                <h5 class="card-text">{{tageler.group[0].slice(0, 24)}}...</h5>
+                <h5 class="card-text group-name">{{tageler.group[0].slice(0, 24)}}...</h5>
               </div>
             </div>
             <div *ngIf="!tageler.group[0]">
-              <h5 class="card-text">{{tageler.group}}</h5>
+              <h5 class="card-text group-name">{{tageler.group}}</h5>
             </div>
             <button id="cardButton2Upcoming" class="btn btn-info" (click)="showTagelerDetailsForm(tageler)">Details</button>
             <button id="cardButton3Upcoming" class="btn btn-info" (click)="showTagelerEditForm(tageler)">Edit</button>
@@ -381,10 +381,10 @@
             <h5 class="card-title">{{tageler.start | date: 'fullDate'}}</h5>
             <div *ngIf="tageler.group[0]">
               <div *ngIf="tageler.group[0].split(',').length <= 3">
-                <h5 class="card-text">{{tageler.group}}</h5>
+                <h5 class="card-text group-name">{{tageler.group}}</h5>
               </div>
               <div *ngIf="tageler.group[0].split(',').length > 3">
-                <h5 class="card-text">{{tageler.group[0].slice(0, 24)}}...</h5>
+                <h5 class="card-text group-name">{{tageler.group[0].slice(0, 24)}}...</h5>
               </div>
             </div>
             <div *ngIf="!tageler.group[0]">
@@ -430,7 +430,7 @@
           <div class="form-group row">
             <label for="formControlName_group" class="col-3 col-form-label">Einheit*:</label>
             <div class="col-9" *ngIf="view">
-              <textarea id="formControlName_group" class="form-control" formControlName="group" value="{{tageler.group}}" autosize></textarea>
+              <textarea id="formControlName_group" class="form-control group-name" formControlName="group" value="{{tageler.group}}" autosize></textarea>
             </div>
           </div>
           <div *ngIf="tageler.free">

--- a/src/app/groups/group-details/group-details.component.html
+++ b/src/app/groups/group-details/group-details.component.html
@@ -1,7 +1,7 @@
 <div class="container" *ngIf="group && !viewCalendar">
   <div class="row">
     <div class="col-md-8">
-      <h3>Tagelers von {{group.name}}</h3>
+      <h3>Tagelers von <span class="group-name">{{group.name}}</span></h3>
     </div>
 
     <!-- Button for iCal and calendar -->
@@ -22,7 +22,7 @@
             <h5 id="date_free" *ngIf="tageler.free"> {{ tageler.start | date: 'fullDate'}}</h5>
             <p id="text" class="card-text" [innerHTML]="tageler.text"></p>
             <p class="card-text"><span class="label">Gruppen:</span></p>
-            <p id="group" class="card-text" [innerHTML]="tageler.group[0].toString().split(',').join('<br \>')"></p>
+            <p id="group" class="card-text group-name" [innerHTML]="tageler.group[0].toString().split(',').join('<br \>')"></p>
             <p id="bringAlong" class="card-text" *ngIf="!tageler.free && tageler.bringAlong"><span class="label">Mitbringen:</span> {{tageler.bringAlong}}</p>
             <p id="uniform" class="card-text" *ngIf="!tageler.free && tageler.uniform"><span class="label">Anziehen:</span> {{tageler.uniform}}</p>
           </div>

--- a/src/app/groups/group.service.ts
+++ b/src/app/groups/group.service.ts
@@ -6,7 +6,7 @@ import 'rxjs/add/operator/toPromise'; // this adds the non-static 'toPromise' op
 @Injectable()
 export class GroupService {
   private groupsUrlGet = '/api/v1/group/getGroups';
-  private groupsUrlGetById = '/api/v1/group/getById';
+  private groupsUrlGetByName = '/api/v1/group/getByName';
 
   constructor(private http: Http) { }
 
@@ -19,8 +19,8 @@ export class GroupService {
   }
 
   // get("/api/v1/group/getById")
-  getGroup(id: String): Promise<Group> {
-    return this.http.get(this.groupsUrlGetById + '/' + id)
+  getGroup(name: String): Promise<Group> {
+    return this.http.get(this.groupsUrlGetByName + '/' + name)
       .toPromise()
       .then(response => response.json() as Group)
       .catch(this.handleError);

--- a/src/app/tagelers/tageler-details/tageler-details.component.html
+++ b/src/app/tagelers/tageler-details/tageler-details.component.html
@@ -17,7 +17,7 @@
             <h5 id="date_free" class="card-text" *ngIf="tageler.free"> {{ tageler.start | date: 'fullDate'}}</h5>
             <p id="text" class="card-text" [innerHTML]="tageler.text | sanitizeHtml"></p>
             <p id="group_title" class="card-text"><span class="label">Gruppen:</span></p>
-            <p id="group" class="card-text" [innerHTML]="tageler.group[0].toString().split(',').join('<br \>')"></p>
+            <p id="group" class="card-text group-name" [innerHTML]="tageler.group[0].toString().split(',').join('<br \>')"></p>
             <p id="bringAlong" class="card-text" *ngIf="!tageler.free && tageler.bringAlong"><span class="label">Mitbringen:</span> {{tageler.bringAlong}}</p>
             <p id="uniform" class="card-text" *ngIf="!tageler.free && tageler.uniform"><span class="label">Anziehen:</span> {{tageler.uniform}}</p>
           </div>

--- a/src/app/tagelers/tageler-list/tageler-list.component.html
+++ b/src/app/tagelers/tageler-list/tageler-list.component.html
@@ -13,7 +13,7 @@
           </div>
           <h5 id="date">{{tageler.start | convertToLocalDate}}</h5>
           <div id="textShort" *ngIf="tageler.group[0].split(',').length <= 4">
-            <p class="card-text">{{tageler.group}}</p>
+            <p class="card-text group-name">{{tageler.group}}</p>
           </div>
           <div id="textLong" *ngIf="tageler.group[0].split(',').length > 4">
             <p class="card-text">{{tageler.group[0].slice(0, 35)}}...</p>

--- a/src/app/tagelers/tageler/tageler.component.html
+++ b/src/app/tagelers/tageler/tageler.component.html
@@ -4,8 +4,8 @@
     <div class="col md-4">
       <h4>Trupp</h4>
       <div *ngFor="let group of groups | groupTypeFilter: 'Trupp' ">
-        <a href="../group/{{group._id}}">
-          <li class="list-group-item">
+        <a href="../group/{{group.name}}">
+          <li class="list-group-item group-name">
             {{group.name}}
           </li>
         </a>
@@ -14,8 +14,8 @@
     <div class="col md-4">
       <h4>Meute</h4>
       <div *ngFor="let group of groups | groupTypeFilter: 'Meute' ">
-        <a href="../group/{{group._id}}">
-          <li class="list-group-item">
+        <a href="../group/{{group.name}}">
+          <li class="list-group-item group-name">
             {{group.name}}
           </li>
         </a>
@@ -24,8 +24,8 @@
     <div class="col md-4">
       <h4>Equipe</h4>
       <div *ngFor="let group of groups | groupTypeFilter: 'Equipe' ">
-        <a href="../group/{{group._id}}">
-          <li class="list-group-item">
+        <a href="../group/{{group.name}}">
+          <li class="list-group-item group-name">
             {{group.name}}
           </li>
         </a>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,3 +2,6 @@
 body {
   font-family: 'Trebuchet MS','Helvetica Neue',Arial,Helvetica,sans-serif;
 }
+.group-name{
+  text-transform: capitalize;
+}


### PR DESCRIPTION
Add getGroupByName as service endpoint
Switch links in group view, to use name instead of _id
Capitalize group names in frontend using CSS

Fixes #66 
Depends on tageler/tageler-api#34