### PR TITLE
Fix name of default image for free

### DIFF
--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -74,7 +74,7 @@ export class AdminComponent implements OnInit {
   ngOnInit() {
     this.fetchTagelers();
     // TODO: change this to default ubungsfrei picture
-    this.defaultPictureService.getDefaultPictureByName('defaultPicture').then((defaultPicture) => {
+    this.defaultPictureService.getDefaultPictureByName('defaultPictureUebungsfrei').then((defaultPicture) => {
       this.defaultPictureUbungsfrei = defaultPicture.picture;
     });
   }


### PR DESCRIPTION
Make sure, the default picture for uebungsfrei, has a unique name

Fixes #56 