### PR TITLE
Replace angular2-color-picker with ngx-color-picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "angular2-flash-messages": "1.0.5",
     "angular2-image-upload": "^0.4.1",
     "angular2-moment": "^1.3.0",
-    "angular2-color-picker": "^1.3.1",
+    "ngx-color-picker": "~2.0.2",
     "angular2-font-picker": "^2.1.1",
     "angular2-froala-wysiwyg": "^2.6.0",
     "core-js": "^2.4.1",
@@ -41,7 +41,7 @@
     "zone.js": "^0.7.6"
   },
   "devDependencies": {
-    "@angular/cli": "1.0.0-rc.1",
+    "@angular/cli": "1.3.0",
     "@angular/compiler-cli": "^2.4.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "~6.0.60",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,7 +12,7 @@ import { FileUploadModule } from 'ng2-file-upload';
 import { ConfirmModule} from 'angular2-bootstrap-confirm';
 import { FlashMessagesModule } from 'angular2-flash-messages';
 import { Autosize } from 'angular2-autosize/src/autosize.directive';
-import { ColorPickerModule } from 'angular2-color-picker';
+import { ColorPickerModule } from 'ngx-color-picker';
 
 import { AppComponent } from './app.component';
 import { TagelerListComponent } from './tagelers/tageler-list/tageler-list.component';


### PR DESCRIPTION
This replaces `angular2-color-picker` with `ngx-color-picker` since this is AOT compatible, but AOT wasn't enabled yet, since I found further issues in our code, that lead to AOT issues.

Fixes #85 