### PR TITLE
Only load tagelers for viewed group, Add message if no tagelers exist

### DIFF
--- a/src/app/groups/group-details/group-details.component.html
+++ b/src/app/groups/group-details/group-details.component.html
@@ -5,25 +5,32 @@
     </div>
 
     <!-- Button for iCal and calendar -->
-    <div class="col-md-4">
+    <div class="col-md-4" *ngIf="hasTagelers">
       <button class="btn btn-secondary" (click)="handleICal(group)">Events herunterladen</button>
     </div>
   </div>
-
-  <!-- Displays next upcoming tageler of the group -->
-  <div class="row" *ngFor="let tageler of tagelers | nextTagelerFilter: group">
-    <tageler-large-card [tageler]="tageler" id="bigCard"></tageler-large-card>
-  </div>
-  <br>
   <hr>
-  <br>
 
-  <!-- Display all other upcoming tagelers as smaller cards -->
-  <div class="row">
-    <div class="groupPipe col-md-4" *ngFor="let tageler of tagelers | otherTagelerFilter: group">
-      <a class="nodecor" routerLink="/tageler-details/{{tageler._id}}">
-        <tageler-small-card [tageler]="tageler"></tageler-small-card>
-      </a>
+  <ng-container *ngIf="hasTagelers">
+    <!-- Displays next upcoming tageler of the group -->
+    <div class="row" *ngFor="let tageler of tagelers | nextTagelerFilter: group">
+      <tageler-large-card [tageler]="tageler" id="bigCard"></tageler-large-card>
     </div>
-  </div>
+    <br>
+    <hr>
+    <br>
+
+    <!-- Display all other upcoming tagelers as smaller cards -->
+    <div class="row">
+      <div class="groupPipe col-md-4" *ngFor="let tageler of tagelers | otherTagelerFilter: group">
+        <a class="nodecor" routerLink="/tageler-details/{{tageler._id}}">
+          <tageler-small-card [tageler]="tageler"></tageler-small-card>
+        </a>
+      </div>
+    </div>
+  </ng-container>
+
+  <ng-container *ngIf="!hasTagelers">
+    Zur Zeit sind für <span class="group-name">{{group.name}}</span> noch keine Tageler erfasst worden.
+  </ng-container>
 </div>

--- a/src/app/groups/group-details/group-details.component.ts
+++ b/src/app/groups/group-details/group-details.component.ts
@@ -14,9 +14,9 @@ import { Group } from '../group';
 })
 
 export class GroupDetailsComponent implements OnInit {
-  @Input()
-  tageler: Tageler;
+
   tagelers: Tageler[];
+  hasTagelers = false;
   group: Group;
   groupEvents = [];
   viewCalendar = false;
@@ -32,22 +32,18 @@ export class GroupDetailsComponent implements OnInit {
     console.log("Init Group Details");
     this.route.params
       .switchMap((params: Params) => this.groupService.getGroup(params['name']))
-      .subscribe(group => this.group = group);
-
-    this.tagelerService
-      .getTagelers()
-      .then((tagelers: Tageler[]) => {
-        this.tagelers = tagelers.map((tageler) => {
-          if (!tageler.title) {
-            tageler.title = 'default';
-          }
-          if (tageler.group.toString().includes(this.group.name)) {
-            this.groupEvents.push({title: tageler.title, start: tageler.start})
-          }
-          this.showGroupDetailsComponent = true;
-          return tageler;
-        });
-      });
+      .subscribe(
+        (group: Group) => {
+          this.group = group;
+          this.tagelerService
+            .getTagelerByGroupname(group.name)
+            .then((tagelers: Tageler[]) => {
+              this.tagelers = tagelers;
+              if (tagelers.length > 0) {
+                this.hasTagelers = true;
+              }
+            });
+        }); 
   }
 
   /*
@@ -61,39 +57,4 @@ export class GroupDetailsComponent implements OnInit {
     window.location.href=link;
   }
 
-  /*
-   * Calendar
-   */
-
-  // handles calendar - if viewCalendar is true, then calendar is displayed
-  handleCalendarView() {
-    this.viewCalendar = !this.viewCalendar;
-  }
-
-  // Set calendar options
-  calendarOptions:Object = {
-    height: 500,
-    fixedWeekCount : false,
-    defaultDate: new Date,
-    locale: 'de-CH',
-    timezone: 'local',
-    timeFormat: 'hh:mm',
-    dayNames: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch',
-      'Donnerstag', 'Freitag', 'Samstag'],
-    dayNamesShort: ['SO', 'MO', 'DI', 'MI', 'DO', 'FR', 'SA'],
-    monthNames: ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli',
-      'August', 'September', 'Oktober', 'November', 'Dezember'],
-    monthNamesShort: ['Jan.', 'Febr.', 'März', 'Apr.', 'Mai', 'Juni',
-      'Juli', 'Aug.', 'Sep.', 'Okt.', 'Nov.', 'Dez.'],
-    buttonText: {
-      today:    'Heute',
-      month:    'Monat',
-      week:     'Woche',
-      day:      'Tag',
-      list:     'Liste'
-    },
-    editable: false,
-    eventLimit: true, // allow "more" link when too many events
-    events: this.groupEvents,
-  };
 }

--- a/src/app/tagelers/tageler-details/tageler-details.component.html
+++ b/src/app/tagelers/tageler-details/tageler-details.component.html
@@ -6,6 +6,7 @@
       <button class="btn btn-secondary" (click)="handleICal(tageler)">Event herunterladen</button>
     </div>
   </div>
+  <hr>
 
   <!-- Displays card of specific tageler -->
   <tageler-large-card [tageler]="tageler"></tageler-large-card>

--- a/src/app/tagelers/tageler-details/tageler-details.component.ts
+++ b/src/app/tagelers/tageler-details/tageler-details.component.ts
@@ -15,13 +15,10 @@ import { Group } from '../../groups/group';
 export class TagelerDetailsComponent implements OnInit {
   @Input()
   tageler: Tageler;
-  tagelers: Tageler[];
-  groups: Group[];
   text: String;
 
   constructor(
     private tagelerService: TagelerService,
-    private groupService: GroupService,
     private route: ActivatedRoute
   ) {}
 
@@ -30,18 +27,6 @@ export class TagelerDetailsComponent implements OnInit {
     this.route.params
       .switchMap((params: Params) => this.tagelerService.getTageler(params['id']))
       .subscribe(tageler => this.tageler = tageler);
-
-
-    this.groupService
-      .getGroups()
-      .then((groups: Group[]) => {
-        this.groups = this.groups = groups.map((group) => {
-          if(!group.name) {
-            group.name = 'default';
-          }
-          return group;
-        });
-      });
   };
 
   /*

--- a/src/app/tagelers/tageler-list/tageler-list.component.ts
+++ b/src/app/tagelers/tageler-list/tageler-list.component.ts
@@ -11,7 +11,6 @@ import { TagelerService } from '../tageler.service';
 export class TagelerListComponent implements OnInit {
 
   tagelers: Tageler[];
-  tageler: Tageler;
 
   constructor(
     private tagelerService: TagelerService) {}
@@ -21,12 +20,7 @@ export class TagelerListComponent implements OnInit {
     this.tagelerService
       .getTagelers()
       .then((tagelers: Tageler[]) => {
-        this.tagelers = tagelers.map((tageler) => {
-          if (!tageler.title) {
-            tageler.title = 'default';
-          }
-          return tageler;
-        });
+        this.tagelers = tagelers;
       });
   }
 }

--- a/src/app/tagelers/tageler.service.ts
+++ b/src/app/tagelers/tageler.service.ts
@@ -4,11 +4,13 @@ import { Http, Headers, RequestOptions } from '@angular/http';
 import 'rxjs/add/operator/toPromise';   // this adds the non-static 'toPromise' operator
 import 'rxjs/add/operator/map';         // this adds the non-static 'map' operator
 import 'rxjs/add/operator/switchMap';   // this adds the non-static 'switchMap' operator
+import { Group } from '../groups/group';
 
 @Injectable()
 export class TagelerService {
   private tagelersUrlPost = '/api/v1/tageler/admin/create';
   private tagelersUrlGet = '/api/v1/tageler/getTagelers';
+  private tagelersUrlGetByGroup = '/api/v1/tageler/getByGroup';
   private tagelersUrlGetById = '/api/v1/tageler/getById';
   private tagelerUrlDelete = '/api/v1/tageler/admin/delete';
   private tagelerUrlUpdate = '/api/v1/tageler/admin/update';
@@ -27,6 +29,14 @@ export class TagelerService {
   // get("/api/v1/tageler/getTagelers")
   getTagelers(): Promise<Tageler[]> {
     return this.http.get(this.tagelersUrlGet)
+      .toPromise()
+      .then(response => response.json() as Tageler[])
+      .catch(this.handleError);
+  }
+
+  // get("/api/v1/tageler/getByGroup")
+  getTagelerByGroupname(groupname: String): Promise<Tageler[]> {
+    return this.http.get(this.tagelersUrlGetByGroup + '/' + groupname)
       .toPromise()
       .then(response => response.json() as Tageler[])
       .catch(this.handleError);

--- a/src/app/tagelers/tageler/tageler.component.ts
+++ b/src/app/tagelers/tageler/tageler.component.ts
@@ -11,42 +11,19 @@ import { GroupService } from '../../groups/group.service';
 })
 
 export class TagelerComponent implements OnInit {
-  tagelers: Tageler[];
   groups: Group[];
 
-
-  @Input()
-  tageler: Tageler;
-
   constructor(
-    private tagelerService: TagelerService,
     private groupService: GroupService,
   ) {}
 
   ngOnInit() {
     console.log("Init");
-    this.tagelerService
-      .getTagelers()
-      .then((tagelers: Tageler[]) => {
-        this.tagelers = tagelers;
-        this.tagelers.sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
-        tagelers.map((tageler) => {
-          if (!tageler.title) {
-            tageler.title = 'default';
-          }
-          return tageler;
-        });
-      });
 
     this.groupService
       .getGroups()
       .then((groups: Group[]) => {
-        this.groups = this.groups = groups.map((group) => {
-          if (!group.name) {
-            group.name = 'default';
-          }
-          return group;
-        });
+        this.groups = groups;
       });
   }
 }


### PR DESCRIPTION
This pull requests improves when what data is loaded from the API.
e.g. on the group overview, we only want to load the groups and not all tagelers as well.
On a group detail page, we only want to load tagelers for this specific group
On a tageler detail page, we don't need to load all groups either