### PR TITLE
Switch date formating to use momentjs

### DIFF
--- a/src/app/pipes/toLocalDatePipe.pipe.ts
+++ b/src/app/pipes/toLocalDatePipe.pipe.ts
@@ -1,4 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import * as moment from 'moment';
+import 'moment/locale/de-ch'
 
 @Pipe({
   name: 'convertToLocalDate',
@@ -13,38 +15,15 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class ToLocalDatePipe implements PipeTransform {
 
   transform(date: Date) {
-    let parsedDateTime;
-    let wochentag, monat;
+    let moment_date, parsedDateTime;
 
     if (date==null) {
       return null;
     }
 
-    // Get name of the day
-    if(new Date(date).getUTCDay() == 0) { wochentag = 'Sonntag'}
-    if(new Date(date).getUTCDay() == 6) { wochentag = 'Samstag'}
-    if(new Date(date).getUTCDay() == 5) { wochentag = 'Freitag'}
-    if(new Date(date).getUTCDay() == 4) { wochentag = 'Donnerstag'}
-    if(new Date(date).getUTCDay() == 3) { wochentag = 'Mittwoch'}
-    if(new Date(date).getUTCDay() == 2) { wochentag = 'Dienstag'}
-    if(new Date(date).getUTCDay() == 1) { wochentag = 'Montag'}
+    moment_date = moment(date).locale('de-ch');
 
-
-    // Get name of the month
-    if(new Date(date).getUTCMonth() == 0) { monat = 'Januar'}
-    if(new Date(date).getUTCMonth() == 1) { monat = 'Februar'}
-    if(new Date(date).getUTCMonth() == 2) { monat = 'März'}
-    if(new Date(date).getUTCMonth() == 3) { monat = 'April'}
-    if(new Date(date).getUTCMonth() == 4) { monat = 'Mai'}
-    if(new Date(date).getUTCMonth() == 5) { monat = 'Juni'}
-    if(new Date(date).getUTCMonth() == 6) { monat = 'Juli'}
-    if(new Date(date).getUTCMonth() == 7) { monat = 'August'}
-    if(new Date(date).getUTCMonth() == 8) { monat = 'September'}
-    if(new Date(date).getUTCMonth() == 9) { monat = 'Oktober'}
-    if(new Date(date).getUTCMonth() == 10) { monat = 'November'}
-    if(new Date(date).getUTCMonth() == 11) { monat = 'Dezember'}
-
-    parsedDateTime = wochentag + ', ' + new Date(date).getUTCDate() + '. ' + monat + ' ' + new Date(date).getUTCFullYear();
+    parsedDateTime = moment_date.format('dddd, DD. MMMM YYYY');
     return parsedDateTime;
   }
 

--- a/src/app/pipes/toLocalTimePipe.pipe.ts
+++ b/src/app/pipes/toLocalTimePipe.pipe.ts
@@ -20,7 +20,7 @@ export class ToLocalTimePipe implements PipeTransform {
       return null;
     }
 
-    return new Date(date).toLocaleTimeString().slice(0, 5);
+    return new Date(date).toLocaleTimeString('de-CH').slice(0, 5);
   }
 
 }

--- a/src/app/pipes/toLocalTimePipe.pipe.ts
+++ b/src/app/pipes/toLocalTimePipe.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import * as moment from 'moment';
 
 @Pipe({
   name: 'convertToLocalTime',
@@ -20,7 +21,7 @@ export class ToLocalTimePipe implements PipeTransform {
       return null;
     }
 
-    return new Date(date).toLocaleTimeString('de-CH').slice(0, 5);
+    return moment(date).format('HH:mm');
   }
 
 }


### PR DESCRIPTION
We already have momentjs as a dependency, but aren't using it in all the places where it would make sense.

To fix #108 I migrated all the date formatting code within pipes to momentjs, and hardcoded to locale to de-ch